### PR TITLE
Adding a deploy to Netlify button

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ npm run build
 npm run serve-production
 ```
 
+## Instant deploy to Netlify
+
+By clicking this button you can automatically clone this repository, setup a new site in [Netlify](https://www.netlify.com) and run the build and deployment to the Netlify CDN.
+
+<!-- Markdown snippet -->
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/maoberlehner/how-to-pre-render-vue-powered-websites-with-webpack)
+
+
+
 ## About
 
 ### Author

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "dist"


### PR DESCRIPTION
This will allow for a one-click deploy to Netlify for new users on this project, including running the build to output the static version of the site on Netlify CI and pushing to the CDN.